### PR TITLE
feat: add hit-box debug overlay for ships and planes

### DIFF
--- a/pkg/mission/drawer/object.go
+++ b/pkg/mission/drawer/object.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/vector"
 	"github.com/samber/lo"
 
+	"github.com/narasux/jutland/pkg/common/constants"
 	"github.com/narasux/jutland/pkg/mission/object"
 	objBullet "github.com/narasux/jutland/pkg/mission/object/bullet"
 	objUnit "github.com/narasux/jutland/pkg/mission/object/unit"
@@ -66,6 +67,55 @@ func weaponResource(
 	target := float64(state.NormalizeZoom(sceneZoom)) / float64(state.DefaultZoom())
 	resourceZoom := closestResourceZoom(target, []int{1, 2, 4})
 	return weaponImg.Get(weapon, status, resourceZoom), target / float64(resourceZoom)
+}
+
+// rotatedRectangleCorners 返回以屏幕坐标为中心、长度沿 Y 轴的旋转矩形四角。
+func rotatedRectangleCorners(centerX, centerY, length, width, rotation float64) [4][2]float64 {
+	halfLength, halfWidth := length/2, width/2
+	corners := [4][2]float64{
+		{-halfWidth, -halfLength},
+		{halfWidth, -halfLength},
+		{halfWidth, halfLength},
+		{-halfWidth, halfLength},
+	}
+
+	sinA, cosA := math.Sincos(rotation * degToRad)
+	for idx, corner := range corners {
+		x, y := corner[0], corner[1]
+		corners[idx] = [2]float64{
+			centerX + x*cosA - y*sinA,
+			centerY + x*sinA + y*cosA,
+		}
+	}
+	return corners
+}
+
+// drawUnitHitBox 按伤害判定使用的中心、长宽和朝向绘制单位受打击范围。
+func drawUnitHitBox(screen *ebiten.Image, ms *state.MissionState, battleUnit objUnit.BattleUnit) {
+	movementState := battleUnit.MovementState()
+	geometricSize := battleUnit.GeometricSize()
+	centerX, centerY := ms.CameraPosToScreen(movementState.CurPos)
+	blockSize := ms.MapBlockDisplaySize()
+	corners := rotatedRectangleCorners(
+		centerX,
+		centerY,
+		geometricSize.Length/constants.MapBlockSize*blockSize,
+		geometricSize.Width/constants.MapBlockSize*blockSize,
+		movementState.CurRotation,
+	)
+	for idx, corner := range corners {
+		nextCorner := corners[(idx+1)%len(corners)]
+		vector.StrokeLine(
+			screen,
+			float32(corner[0]),
+			float32(corner[1]),
+			float32(nextCorner[0]),
+			float32(nextCorner[1]),
+			2,
+			colorx.Red,
+			false,
+		)
+	}
 }
 
 // 绘制医疗船治疗范围圈（仅在选中己方医疗船时显示）
@@ -135,6 +185,9 @@ func (d *Drawer) drawBattleShips(screen *ebiten.Image, ms *state.MissionState) {
 		sImg, sImgScale := shipResource(s.Name, ms.UI.GameOpts.Zoom)
 		shipX, shipY := ms.CameraPosToScreen(s.CurPos)
 		drawImageCentered(screen, sImg, shipX, shipY, s.CurRotation, sImgScale)
+		if ms.UI.DebugFlags.ShowHitBoxes {
+			drawUnitHitBox(screen, ms, s)
+		}
 
 		// 如果战舰被选中 或 全局启用状态展示，则需要绘制 HP，武器状态
 		isShipSelected := slices.Contains(ms.Interaction.SelectedShips, s.Uid)
@@ -304,6 +357,9 @@ func (d *Drawer) drawFlyingPlanes(screen *ebiten.Image, ms *state.MissionState) 
 		pImg, pImgScale := planeResource(p.Name, ms.UI.GameOpts.Zoom)
 		planeX, planeY := ms.CameraPosToScreen(p.CurPos)
 		drawImageCentered(screen, pImg, planeX, planeY, p.CurRotation, pImgScale)
+		if ms.UI.DebugFlags.ShowHitBoxes {
+			drawUnitHitBox(screen, ms, p)
+		}
 
 		// DEBUG: 如果启用了调试显示飞机 HP，则在飞机上部显示生命值
 		if ms.UI.DebugFlags.ShowPlaneHP {

--- a/pkg/mission/drawer/object_test.go
+++ b/pkg/mission/drawer/object_test.go
@@ -1,0 +1,56 @@
+package drawer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRotatedRectangleCorners(t *testing.T) {
+	tests := []struct {
+		name     string
+		rotation float64
+		want     [4][2]float64
+	}{
+		{
+			name:     "zero degrees keeps length on Y axis",
+			rotation: 0,
+			want: [4][2]float64{
+				{9, 16},
+				{11, 16},
+				{11, 24},
+				{9, 24},
+			},
+		},
+		{
+			name:     "forty-five degrees rotates clockwise",
+			rotation: 45,
+			want: [4][2]float64{
+				{12.121320343559642, 16.464466094067262},
+				{13.535533905932738, 17.878679656440358},
+				{7.878679656440358, 23.535533905932738},
+				{6.464466094067262, 22.121320343559642},
+			},
+		},
+		{
+			name:     "ninety degrees rotates length onto X axis",
+			rotation: 90,
+			want: [4][2]float64{
+				{14, 19},
+				{14, 21},
+				{6, 21},
+				{6, 19},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rotatedRectangleCorners(10, 20, 8, 2, tt.rotation)
+			for idx := range got {
+				assert.InDelta(t, tt.want[idx][0], got[idx][0], 1e-9)
+				assert.InDelta(t, tt.want[idx][1], got[idx][1], 1e-9)
+			}
+		})
+	}
+}

--- a/pkg/mission/hacker/Readme.md
+++ b/pkg/mission/hacker/Readme.md
@@ -324,6 +324,7 @@ Enter 的详细流程：
   - `DamageColorByTeam`
   - `ShowCursorPosObjInfo`
   - `ShowPlaneHP`
+  - `ShowHitBoxes`
 
 `DamageColorByTeam`
 
@@ -342,6 +343,12 @@ Enter 的详细流程：
 - 命令：`show plane hp`
 - 切换 `misState.UI.DebugFlags.ShowPlaneHP`。
 - 用于显示飞机当前 HP 和总 HP。
+
+`ShowHitBoxes`
+
+- 命令：`show hit boxes`
+- 切换 `misState.UI.DebugFlags.ShowHitBoxes`。
+- 用红色旋转矩形显示当前舰船和飞机实际使用的受打击范围。
 
 ## 当前实现特点
 

--- a/pkg/mission/hacker/cheat/cheat.go
+++ b/pkg/mission/hacker/cheat/cheat.go
@@ -27,4 +27,5 @@ var DebugCheats = []Cheat{
 	&DamageColorByTeam{},
 	&ShowCursorPosObjInfo{},
 	&ShowPlaneHP{},
+	&ShowHitBoxes{},
 }

--- a/pkg/mission/hacker/cheat/debug.go
+++ b/pkg/mission/hacker/cheat/debug.go
@@ -26,6 +26,7 @@ func (c *DebugAll) Exec(misState *state.MissionState) string {
 		DamageColorByTeam:    true,
 		ShowCursorPosObjInfo: true,
 		ShowPlaneHP:          true,
+		ShowHitBoxes:         true,
 	}
 	return "Enabled all debug flags"
 }
@@ -100,3 +101,26 @@ func (c *ShowPlaneHP) Exec(misState *state.MissionState) string {
 }
 
 var _ Cheat = (*ShowPlaneHP)(nil)
+
+// ShowHitBoxes -> 修改是否显示舰船和飞机的受打击范围
+type ShowHitBoxes struct{}
+
+func (c *ShowHitBoxes) String() string {
+	return "show hit boxes"
+}
+
+func (c *ShowHitBoxes) Desc() string {
+	return "switch ship and plane hit boxes on/off"
+}
+
+func (c *ShowHitBoxes) Match(cmd string) bool {
+	return isCommandEqual(c.String(), cmd)
+}
+
+func (c *ShowHitBoxes) Exec(misState *state.MissionState) string {
+	nextState := !misState.UI.DebugFlags.ShowHitBoxes
+	misState.UI.DebugFlags.ShowHitBoxes = nextState
+	return "Toggled hit boxes: " + lo.Ternary(nextState, "on", "off")
+}
+
+var _ Cheat = (*ShowHitBoxes)(nil)

--- a/pkg/mission/hacker/cheat/debug_test.go
+++ b/pkg/mission/hacker/cheat/debug_test.go
@@ -1,0 +1,38 @@
+package cheat
+
+import (
+	"testing"
+
+	"github.com/narasux/jutland/pkg/mission/state"
+)
+
+func TestShowHitBoxes(t *testing.T) {
+	cheat := &ShowHitBoxes{}
+	if !cheat.Match("SHOW hitboxes") {
+		t.Fatal("ShowHitBoxes should ignore case and whitespace")
+	}
+
+	misState := &state.MissionState{}
+	if got := cheat.Exec(misState); got != "Toggled hit boxes: on" {
+		t.Fatalf("unexpected enable output: %q", got)
+	}
+	if !misState.UI.DebugFlags.ShowHitBoxes {
+		t.Fatal("ShowHitBoxes should enable the hit-box overlay")
+	}
+
+	if got := cheat.Exec(misState); got != "Toggled hit boxes: off" {
+		t.Fatalf("unexpected disable output: %q", got)
+	}
+	if misState.UI.DebugFlags.ShowHitBoxes {
+		t.Fatal("ShowHitBoxes should disable the hit-box overlay")
+	}
+}
+
+func TestDebugAllEnablesHitBoxes(t *testing.T) {
+	misState := &state.MissionState{}
+	(&DebugAll{}).Exec(misState)
+
+	if !misState.UI.DebugFlags.ShowHitBoxes {
+		t.Fatal("DebugAll should enable the hit-box overlay")
+	}
+}

--- a/pkg/mission/state/debug.go
+++ b/pkg/mission/state/debug.go
@@ -8,9 +8,11 @@ type DebugFlags struct {
 	ShowCursorPosObjInfo bool
 	// ShowPlaneHP 显示飞机生命值（当前 HP / 总 HP）
 	ShowPlaneHP bool
+	// ShowHitBoxes 显示舰船和飞机的受打击范围
+	ShowHitBoxes bool
 }
 
 // IsActive 判断是否有任何调试标志已启用
 func (f DebugFlags) IsActive() bool {
-	return f.DamageColorByTeam || f.ShowCursorPosObjInfo || f.ShowPlaneHP
+	return f.DamageColorByTeam || f.ShowCursorPosObjInfo || f.ShowPlaneHP || f.ShowHitBoxes
 }

--- a/pkg/mission/state/debug_test.go
+++ b/pkg/mission/state/debug_test.go
@@ -1,0 +1,12 @@
+package state
+
+import "testing"
+
+func TestDebugFlagsIsActiveWithHitBoxes(t *testing.T) {
+	if !(DebugFlags{ShowHitBoxes: true}).IsActive() {
+		t.Fatal("ShowHitBoxes should activate debug mode")
+	}
+	if (DebugFlags{}).IsActive() {
+		t.Fatal("zero-value DebugFlags should be inactive")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `show hit boxes` hacker cheat to toggle hit-box rendering for ships and planes
- Draw each unit's actual rotated damage rectangle in red when the debug flag is enabled
- Update debug flag aggregation and hacker docs to include the new overlay
- Add tests for hit-box corner math, cheat toggling, and debug flag activation

## Testing
- Added unit coverage for rotated rectangle corner placement and debug cheat behavior
- Added state-level coverage for `DebugFlags.IsActive()` with the new flag
- Not run (not requested)